### PR TITLE
Fixed deepestChild() test

### DIFF
--- a/test/index-test.js
+++ b/test/index-test.js
@@ -15,7 +15,7 @@ describe('index', () => {
   describe('deepestChild()', () => {
     it('returns the most deeply nested child in #grand-node', () => {
       console.log(deepestChild().innerHTML)
-      expect(deepestChild()).toEqual(document.querySelector('#grand-node div div div div'))
+      expect(deepestChild()).toBe(document.querySelector('#grand-node div div div div'))
     })
   })
 


### PR DESCRIPTION
Previously the `deepestChild()` test used `.toEqual()`, which does deep checking. If a student returned `'div#grand-node'` or _any_ of it's children, this test would pass. I've switched it to `.toBe()` so now this test requires the correct node to be returned.

@aturkewi 