### PR TITLE
tests to make sure lists are not empty either

### DIFF
--- a/test/index-test.js
+++ b/test/index-test.js
@@ -29,6 +29,8 @@ describe('index', () => {
 
       let children = firstList.children
       let start = 1
+
+      expect(children.length).to.equal(2);
       for (let i = 0, l = children.length; i < l; i++) {
         expect(parseInt(children[i].innerHTML)).to.equal(start + i + 3)
       }
@@ -36,6 +38,7 @@ describe('index', () => {
       children = secondList.children
       start = 12
 
+      expect(children.length).to.equal(3);
       for (let i = 0, l = children.length; i < l; i++) {
         expect(parseInt(children[i].innerHTML)).to.equal(start - i + 3)
       }


### PR DESCRIPTION
a student was iterating over the uls and replacing them with NaN (from parseInt) accidentally which would still pass the tests because then there would be nothing in the `children` arrays in the test meaning we never iterate meaning we never hit an expect
this will also give a better error for that instance
@drakeltheryuujin 